### PR TITLE
Fix variable name in GetShouldRoll

### DIFF
--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -52,9 +52,9 @@ bool Configuration::GetShouldStall()
 
 bool Configuration::GetShouldRoll()
 {
-    std::string shouldStall = GetAttribute("should_roll");
+    std::string shouldRoll = GetAttribute("should_roll");
 
-    return shouldStall == "true" ? true : false;
+    return shouldRoll == "true" ? true : false;
 }
 
 int Configuration::GetStallThreshold()


### PR DESCRIPTION
## Summary
- correct variable naming in `Configuration::GetShouldRoll()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6847ed6b9b34832c89007b18940ac6e3